### PR TITLE
Update SubmissionListComponent styles heavily

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpglb",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "ng": "ng",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -47,6 +47,7 @@ import { SubmissionListComponent } from './submission-list/submission-list.compo
 import { SubmissionsListPageComponent } from './submissions-list-page/submissions-list-page.component'
 import { TimeRangeValidatorDirective } from './time-range.directive'
 import { TimeToStringPipe } from './time-to-string.pipe'
+import { TruncatePipe } from './truncate.pipe'
 import { UserListComponent } from './user-list/user-list.component'
 import { UserService } from './user.service'
 import { VerifyPageComponent } from './verify-page/verify-page.component'
@@ -76,6 +77,7 @@ import { VerifyPageComponent } from './verify-page/verify-page.component'
 		TimeToStringPipe,
 		SubmissionsListPageComponent,
 		PreEventHomePageComponent,
+		TruncatePipe,
 	],
 	entryComponents: [
 		SubmissionConfirmationDialogComponent

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -7,7 +7,7 @@
 		<a href="/tracker/6">TRACKER</a>
 		<a *ngIf="mode === 'event'" routerLink="/rules">EVENT RULES</a>
 		<a *ngIf="areSubmissionsOpen" routerLink="/submissions">SUBMISSIONS</a>
-		<a href="https://discord.gg/rpglb" target="_blank">DISCORD</a>
+		<a href="https://discord.gg/rpglb" class="no-icon" target="_blank">DISCORD</a>
 		<!-- <a routerLink="about">ABOUT</a> -->
 		<div class="auth-container" *ngIf="isLoggedIn()">
 			<a routerLink="/profile">PROFILE</a>

--- a/src/app/profile/profile.component.html
+++ b/src/app/profile/profile.component.html
@@ -1,14 +1,13 @@
 <div class="wrapper">
 	<h1 class="no-bold">{{user.username}}</h1>
 	<h3>Your submissions</h3>
-	<mat-card *ngIf="areSubmissionsOpen && games && games.length > 0">
+	<ng-container *ngIf="areSubmissionsOpen && games && games.length > 0">
 		<app-submission-list #submissionList
 			[dataSource]="games"
 			[showFilter]="false"
-			[showRunner]="false"
 			[showPagination]="false">
 		</app-submission-list>
-	</mat-card>
+	</ng-container>
 	<div *ngIf="areSubmissionsOpen && (!games || (games && games.length === 0))">You haven't submitted any games to {{event}}</div>
 	<div *ngIf="!areSubmissionsOpen">Submissions aren't quite open. Check back later.</div>
 	<br />

--- a/src/app/submission-list/submission-list.component.html
+++ b/src/app/submission-list/submission-list.component.html
@@ -9,71 +9,71 @@
 		</mat-form-field>
 	</div>
 
-	<!--
-		Common sense would use *ngIf directive on mat-paginator here, but this does not work with @ViewChild and
- 		[hidden] doesn't work on mat-paginator directly, hence the wrapper element
-	-->
-	<div [hidden]="!showPagination">
-		<mat-paginator #paginatorTop
-			[length]="resultsLength"
-			[pageSize]="defaultPageSize"
-			[pageSizeOptions]="[5, 10, 20, 50, 5000]"
-			[showFirstLastButtons]="true"
-			(page)="onPageChange($event)">
-		</mat-paginator>
-	</div>
-
 	<mat-table #table [dataSource]="dataSource"
 	           matSort matSortActive="name" matSortDisableClear matSortDirection="asc">
 
 		<ng-container matColumnDef="runner">
-			<mat-header-cell *matHeaderCellDef mat-sort-header>Runner</mat-header-cell>
-			<mat-cell *matCellDef="let submission">{{submission.runner | idToUsername | async}}</mat-cell>
+			<mat-header-cell *matHeaderCellDef>
+				<div mat-sort-header="name">Game</div>
+				<div mat-sort-header="console">Console</div>
+				<div mat-sort-header="runner">Runner</div>
+			</mat-header-cell>
+			<mat-cell *matCellDef="let submission">
+				<span class="cell-title">{{submission.name}}</span>
+				<div class="cell-subtitle">on {{submission.console}}</div>
+				<div class="runner">&mdash; {{submission.runner | idToUsername | async}}</div>
+			</mat-cell>
 		</ng-container>
 
 		<ng-container matColumnDef="name">
-			<mat-header-cell *matHeaderCellDef
-				mat-sort-header disableClear="true">Game</mat-header-cell>
+			<mat-header-cell *matHeaderCellDef>Game</mat-header-cell>
 			<mat-cell *matCellDef="let submission">{{submission.name}}</mat-cell>
 		</ng-container>
 
 		<ng-container matColumnDef="console">
-			<mat-header-cell *matHeaderCellDef mat-sort-header>Console</mat-header-cell>
+			<mat-header-cell *matHeaderCellDef>Console</mat-header-cell>
 			<mat-cell *matCellDef="let submission">{{submission.console}}</mat-cell>
 		</ng-container>
 
 		<ng-container matColumnDef="description">
 			<mat-header-cell *matHeaderCellDef>Description</mat-header-cell>
-			<mat-cell *matCellDef="let submission" class="preserve-newlines">{{submission.description}}</mat-cell>
+			<mat-cell *matCellDef="let submission" class="preserve-newlines">{{!submission.expand ? (submission.description | truncate:100+(200*submission.categories.length):true) : submission.description}}</mat-cell>
 		</ng-container>
 
-		<ng-container matColumnDef="pros">
-			<mat-header-cell *matHeaderCellDef>Pros</mat-header-cell>
-			<mat-cell *matCellDef="let submission" class="preserve-newlines">{{submission.pros}}</mat-cell>
-		</ng-container>
-
-		<ng-container matColumnDef="cons">
-			<mat-header-cell *matHeaderCellDef>Cons</mat-header-cell>
-			<mat-cell *matCellDef="let submission" class="preserve-newlines">{{submission.cons}}</mat-cell>
+		<ng-container matColumnDef="proscons">
+			<mat-header-cell *matHeaderCellDef>Pros &amp; Cons</mat-header-cell>
+			<mat-cell *matCellDef="let submission">
+				<ng-container *ngIf="submission.pros">
+					<span class="cell-subtitle">PROS</span>
+					<div class="preserve-newlines">{{!submission.expand ? (submission.pros | truncate:100+50*submission.categories.length:true) : submission.pros}}</div>
+					<br />
+				</ng-container>
+				<ng-container *ngIf="submission.cons">
+					<span class="cell-subtitle">CONS</span>
+					<div class="preserve-newlines">{{!submission.expand ? (submission.cons | truncate:100+50*submission.categories.length:true) : submission.cons}}</div>
+				</ng-container>
+			</mat-cell>
 		</ng-container>
 
 		<ng-container matColumnDef="incentives">
 			<mat-header-cell *matHeaderCellDef>Incentives</mat-header-cell>
-			<mat-cell *matCellDef="let submission" class="preserve-newlines">{{submission.incentives}}</mat-cell>
+			<mat-cell *matCellDef="let submission" class="preserve-newlines">{{!submission.expand ? (submission.incentives | truncate:100+200*submission.categories.length:true) : submission.incentives}}</mat-cell>
 		</ng-container>
 
 		<ng-container matColumnDef="categories">
 			<mat-header-cell *matHeaderCellDef>Categories</mat-header-cell>
 			<mat-cell *matCellDef="let submission">
-				<div *ngFor="let cat of submission.categories">
+				<div *ngFor="let cat of submission.categories" class="category-container">
 					<a *ngIf="hasSubmissionsRole"
+						class="cell-title"
 						[href]="cat.video.includes('http') ? cat.video : 'http://' + cat.video"
 						target="_blank">
-						{{cat.name}} - {{cat.estimate | timeToString}}
-					</a>
-					<span *ngIf="!hasSubmissionsRole">
-						{{cat.name}} - {{cat.estimate | timeToString}}
-					</span>
+						{{cat.name}}</a>
+					<span *ngIf="!hasSubmissionsRole" class="cell-title">{{cat.name}}</span>
+					<div class="cell-subtitle">EST: {{cat.estimate | timeToString}}</div>
+					<br />
+					<div class="description preserve-newlines">{{!submission.expand ? (cat.description | truncate:100:true) : cat.description}}</div>
+					<hr *ngIf="submission.categories.indexOf(cat) < submission.categories.length - 1"/>
 				</div>
 			</mat-cell>
 		</ng-container>
@@ -94,13 +94,13 @@
 					<h3>Visibility</h3>
 					<button mat-raised-button
 						color="primary"
-						(click)="markSubmission(submission, 'public', $event.target.closest('button'))">
+						(click)="markSubmission(submission, 'public', $event)">
 						<span>Mark Public</span>
 						<mat-spinner color="primary" [diameter]="28"></mat-spinner>
 					</button>
 					<button mat-raised-button
 						color="warn"
-						(click)="markSubmission(submission, 'private', $event.target.closest('button'))">
+						(click)="markSubmission(submission, 'private', $event)">
 						<span>Mark Private</span>
 						<mat-spinner color="warn" [diameter]="28"></mat-spinner>
 					</button>
@@ -108,28 +108,28 @@
 					<button mat-raised-button
 						color="primary"
 						disabled
-						(click)="markSubmission(submission, 'accept', $event.target.closest('button'))">
+						(click)="markSubmission(submission, 'accept', $event)">
 						<span>Mark Accepted</span>
 						<mat-spinner color="primary" [diameter]="28"></mat-spinner>
 					</button>
 					<button mat-raised-button
 						color="accent"
 						disabled
-						(click)="markSubmission(submission, 'backup', $event.target.closest('button'))">
+						(click)="markSubmission(submission, 'backup', $event)">
 						<span>Mark Backup</span>
 						<mat-spinner color="accent" [diameter]="28"></mat-spinner>
 					</button>
 					<button mat-raised-button
 						color="warn"
 						disabled
-						(click)="markSubmission(submission, 'reject', $event.target.closest('button'))">
+						(click)="markSubmission(submission, 'reject', $event)">
 						<span>Mark Rejected</span>
 						<mat-spinner color="warn" [diameter]="28"></mat-spinner>
 					</button>
 					<h3>Removal</h3>
 					<button mat-raised-button
 						color="warn"
-						(click)="deleteSubmission(submission)">
+						(click)="deleteSubmission(submission);$event.stopPropagation()">
 						<span>DELETE</span>
 						<mat-spinner color="warn" [diameter]="28"></mat-spinner>
 					</button>
@@ -137,21 +137,23 @@
 			</mat-cell>
 		</ng-container>
 
-		<mat-header-row *matHeaderRowDef="columnsToDisplay"></mat-header-row>
-		<mat-row *matRowDef="let row; columns: columnsToDisplay"></mat-row>
+		<mat-header-row *matHeaderRowDef="columnsToDisplay" class="mat-row-sticky top"></mat-header-row>
+		<mat-row *matRowDef="let row; columns: columnsToDisplay"
+			[ngClass]="{'collapsible': isRowCollapsible(row), 'expanded': row.expand}"
+			(click)="row.expand = !row.expand">
+		</mat-row>
 	</mat-table>
 
 	<!--
 		Common sense would use *ngIf directive on mat-paginator here, but this does not work with @ViewChild and
- 		[hidden] doesn't work on mat-paginator directly, hence the wrapper element
+		[hidden] doesn't work on mat-paginator directly, hence the wrapper element
 	-->
-	<div [hidden]="!showPagination">
-		<mat-paginator #paginatorBottom
+	<div [hidden]="!showPagination" class="mat-row-sticky bottom">
+		<mat-paginator #paginator
 			[length]="resultsLength"
 			[pageSize]="defaultPageSize"
-			[pageSizeOptions]="[5, 10, 20, 50, 5000]"
-			[showFirstLastButtons]="true"
-			(page)="onPageChange($event)">
+			[pageSizeOptions]="[5, 10, 50, 100, 5000]"
+			[showFirstLastButtons]="true">
 		</mat-paginator>
 	</div>
 </div>

--- a/src/app/submission-list/submission-list.component.scss
+++ b/src/app/submission-list/submission-list.component.scss
@@ -36,24 +36,115 @@ $background: map-get($rpglb-app-theme, background);
 	width: 100%;
 }
 
-.mat-column-description,
-.mat-column-pros,
-.mat-column-cons,
-.mat-column-incentives,
-.mat-column-controls {
+.mat-row-sticky {
+	position: sticky;
+	z-index: 10;
+	background: mat-color($background, card);
+
+	&.top {
+		top: 0;
+	}
+	&.bottom {
+		bottom: 0;
+		border-top: 1px solid mat-color($foreground, dividers);
+	}
+}
+
+.mat-row {
+	align-items: flex-start;
+	flex-wrap: wrap;
+}
+
+.mat-column-runner {
 	flex: 2;
 }
 
-.mat-cell, .mat-header-cell {
-	padding: 10px;
+.mat-column-description,
+.mat-column-proscons,
+.mat-column-incentives,
+.mat-column-categories,
+.mat-column-controls {
+	flex: 3;
+}
+
+// These columns are purely used for sorting and are thus hidden
+.mat-column-name,
+.mat-column-console {
+	display: none;
+}
+
+.mat-column-proscons .title {
+	margin-bottom: 0;
+	text-align: left;
+}
+
+.category-container {
+	.cell-title {
+		color: mat-color($accent, lighter);
+		word-wrap: normal;
+	}
+	hr {
+		margin-top: 10px;
+		border: 1px solid mat-color($foreground, dividers);
+	}
+}
+
+.cell-title {
+	font-size: 1.2em;
+	font-weight: bold;
+	color: mat-color($primary, 200);
+}
+
+.cell-subtitle {
+	color: mat-color($foreground, base, 0.7);
+	font-style: italic;
+}
+
+.runner {
+	font-size: 1.1em;
+}
+
+.collapsible {
+	cursor: pointer;
+}
+
+.collapsible::after {
+	display: block;
+	font-family: 'Material Icons';
+	font-size: 1.5em;
+	color: mat-color($foreground, base, 0.7);
+	content: 'expand_more';
+	text-align: center;
+	flex-basis: 100%;
+}
+
+.collapsible.expanded::after {
+	content: 'expand_less';
+}
+
+.collapsible:hover {
+	background-color: mat-color($background, hover);
+}
+
+.mat-cell {
+	padding: 25px;
+}
+
+.mat-header-cell {
+	padding: 10px 25px;
 }
 
 .mat-cell > .controls-group {
 	display: flex;
 	flex-direction: column;
+	justify-content: flex-start;
 	align-items: flex-start;
 	border: 0;
 	padding: 0;
+
+	h3:first-of-type {
+		margin-top: 0;
+	}
 }
 
 .controls-group > button {

--- a/src/app/truncate.pipe.spec.ts
+++ b/src/app/truncate.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { TruncatePipe } from './truncate.pipe';
+
+describe('TruncatePipe', () => {
+  it('create an instance', () => {
+    const pipe = new TruncatePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/truncate.pipe.ts
+++ b/src/app/truncate.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core'
+
+@Pipe({
+	name: 'truncate'
+})
+export class TruncatePipe implements PipeTransform {
+
+	transform(value: string, limit: number = 200, wholeWords: boolean = false, mark: string = '...'): string {
+		if (!value || value.length <= limit) {
+			return value
+		}
+
+		if (wholeWords) {
+			limit = value.substr(0, limit).lastIndexOf(' ')
+		}
+		return `${value.substr(0, limit)}${mark}`
+	}
+
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -56,7 +56,6 @@ a:hover {
 
 .title > a {
 	font-weight: bold;
-	/* color: var(--color-accent); */
 }
 
 .dim {
@@ -114,4 +113,12 @@ a:hover {
 
 .no-action .mat-simple-snackbar {
 	justify-content: center;
+}
+
+a[href]:not([href*='rpglimitbreak.com']):not([href*='localhost']):not([href^='#']):not([href^='/']):not(.no-icon)::after {
+	font-family: 'Material Icons';
+	content: 'open_in_new';
+	margin-left: 2px;
+	font-size: 0.7em;
+	vertical-align: super;
 }


### PR DESCRIPTION
The `SubmissionListComponent` was always meant to be more than a simple
data table. This changeset enacts several measures to improve the
overall aesthetic of the component. A few other minor changes were made
site-wide as well to support these changes.

Changes:
- Added `TruncatePipe` for truncating text
- Added external link icon site-wide
- Removed top paginator from `SubmissionListComponent` in favor of
making the bottom paginator sticky
- Overhauled styles for `SubmissionListComponent` data table:
  - Combined 'runner', 'console', and 'game' columns into a single
  column (visually)
  - Combined 'pros' and 'cons' columns
  - Made header and footer sticky for easier access when scrolling
  - Added some nicer styling to categories column
  - Made rows with lots of text collapsible
  - Aligned everything left/top
- Moved `SubmissionListComponent` in `ProfileComponent` out of `MatCard`
- Changed default page size options for `SubmissionListComponent` table

Closes #9