### PR TITLE
Add support for game submissions across multiple events

### DIFF
--- a/controllers/game-submissions.controller.js
+++ b/controllers/game-submissions.controller.js
@@ -23,6 +23,11 @@ exports.getSubmissions = async function (req, res, next) {
 		query.runner = req.query.user
 	}
 
+	// Get submissions for one event specifically
+	if (req.query.speedrunEvent) {
+		query.speedrunEvent = req.query.speedrunEvent
+	}
+
 	let statusArray = []
 	if (req.query.selection) {
 		let selectionQuery = req.query.selection
@@ -76,7 +81,7 @@ exports.createSubmission = async function (req, res, next) {
 	}
 
 	let activeEvent = await SpeedrunEventService.getActiveSpeedrunEvent()
-	if (!activeEvent.areGameSubmissionsOpen &&
+	if (!activeEvent || !activeEvent.areGameSubmissionsOpen &&
 		(!req.user.roles || !req.user.roles.includes('submissions') || !req.user.roles.includes('admin'))
 	) {
 		console.warn('Unauthorized submission creation attempted', req.user, req.body)
@@ -97,7 +102,8 @@ exports.createSubmission = async function (req, res, next) {
 		public: req.body.public,
 		selectionStatus: req.body.selectionStatus,
 		selectionComment: req.body.selectionComment,
-		categories: req.body.categories
+		categories: req.body.categories,
+		speedrunEvent: activeEvent.id
 	}
 
 	try {

--- a/models/game-submission.model.js
+++ b/models/game-submission.model.js
@@ -84,6 +84,11 @@ let GameSubmissionSchema = new mongoose.Schema({
 		type: [CategorySchema],
 		validate: [numCategoriesValidator, '{PATH} either has too few or too many items'],
 		required: true
+	},
+	speedrunEvent: {
+		type: mongoose.Schema.ObjectId,
+		ref: 'SpeedrunEvent',
+		required: true
 	}
 })
 

--- a/services/game-submissions.service.js
+++ b/services/game-submissions.service.js
@@ -30,7 +30,8 @@ exports.createSubmission = async function (submission) {
 		pros: submission.pros,
 		cons: submission.cons,
 		public: submission.public,
-		categories: submission.categories
+		categories: submission.categories,
+		speedrunEvent: submission.speedrunEvent
 	})
 
 	try {

--- a/src/app/profile/profile.component.ts
+++ b/src/app/profile/profile.component.ts
@@ -37,13 +37,13 @@ export class ProfileComponent implements OnInit {
 		this.speedrunEventService.getCurrentSpeedrunEvent()
 			.subscribe((srEvent: SpeedrunEvent) => {
 				this.speedrunEvent = srEvent
+				this.submissionService.getSubmissionsForUser(this.user._id, this.speedrunEvent._id)
+					.map((data: GameSubmissionResponse) => data.docs )
+					.subscribe((data: GameSubmission[]) => {
+						this.games = data
+					})
 			})
 		this.user = this.auth.getUserInfo()
-		this.submissionService.getSubmissionsForUser(this.user._id)
-			.map((data: GameSubmissionResponse) => data.docs )
-			.subscribe((data: GameSubmission[]) => {
-				this.games = data
-			})
 	}
 
 	changePassword() {

--- a/src/app/speedrun-event.service.ts
+++ b/src/app/speedrun-event.service.ts
@@ -9,6 +9,7 @@ import { GameSubmission } from './submission.service'
 import { User } from './user'
 
 export interface SpeedrunEvent {
+	_id?: string,
 	name: string,
 	shortname?: string,
 	cause?: object,

--- a/src/app/speedrun-event.ts
+++ b/src/app/speedrun-event.ts
@@ -1,15 +1,15 @@
-import { DonationService } from './donation.service';
+import { DonationService } from './donation.service'
 
 export class SpeedrunEvent {
-	name: string;
-	shortName: string;
-	cause: string;
-	causeLink: string;
-	donations: DonationData;
-	trackerId: number;
+	name: string
+	shortName: string
+	cause: string
+	causeLink: string
+	donations: DonationData
+	trackerId: number
 }
 
 export interface DonationData {
-	goal: number;
-	total: number;
+	goal: number
+	total: number
 }

--- a/src/app/submission-form/submission-form.component.ts
+++ b/src/app/submission-form/submission-form.component.ts
@@ -30,16 +30,16 @@ export class SubmissionFormComponent implements OnInit {
 	) {}
 
 	ngOnInit() {
+		const userId = this.auth.getUserInfo()._id
 		this.speedrunEventService.getCurrentSpeedrunEvent()
 			.subscribe((srEvent: SpeedrunEvent) => {
 				this.areSubmissionsOpen = srEvent.areGameSubmissionsOpen
-			})
 
-		const userId = this.auth.getUserInfo()._id
-		this.submissionService.getSubmissionsForUser(userId)
-			.map((data: GameSubmissionResponse) => data.docs )
-			.subscribe((data: GameSubmission[]) => {
-				this.games = data
+				this.submissionService.getSubmissionsForUser(userId, srEvent._id)
+					.map((data: GameSubmissionResponse) => data.docs )
+					.subscribe((data: GameSubmission[]) => {
+						this.games = data
+					})
 			})
 	}
 

--- a/src/app/submission-list/submission-list.component.ts
+++ b/src/app/submission-list/submission-list.component.ts
@@ -116,7 +116,6 @@ export class SubmissionListComponent implements OnInit {
 				startWith({}),
 				switchMap(() => {
 					this.isLoadingResults = true
-					console.log('DEBUG: SPEEDRUN EVENT', this.speedrunEventId)
 					return this.submissionService.getSubmissions(
 						this.selectionQuery,
 						this.sort.active,
@@ -142,7 +141,6 @@ export class SubmissionListComponent implements OnInit {
 	}
 
 	applyFilter(filterValue: string) {
-		console.log(this.dataSource)
 		filterValue = filterValue.trim()
 		filterValue = filterValue.toLowerCase()
 		if (filterValue.includes('selection:')) {

--- a/src/app/submission-list/submission-list.component.ts
+++ b/src/app/submission-list/submission-list.component.ts
@@ -19,6 +19,7 @@ import { startWith } from 'rxjs/operators/startWith'
 import { switchMap } from 'rxjs/operators/switchMap'
 
 import { AuthenticationService } from '../authentication.service'
+import { SpeedrunEvent, SpeedrunEventService } from '../speedrun-event.service'
 import { SubmissionConfirmationDialogComponent } from '../submission-form/submission-form.component'
 import { GameSubmission, GameSubmissionResponse, SubmissionService } from '../submission.service'
 
@@ -32,6 +33,7 @@ export class SubmissionListComponent implements OnInit {
 	@Input() columnsToDisplay: string[] = ['name', 'console', 'description', 'proscons', 'incentives', 'categories']
 	@Input() initialPageSize: number = 10
 	@Input() dataSource: MatTableDataSource<GameSubmission> = new MatTableDataSource<GameSubmission>()
+	@Input() speedrunEventId: string
 	@Input() showRunner: boolean = true
 	@Input() showPagination: boolean = true
 	@Input() showFilter: boolean = true
@@ -44,7 +46,7 @@ export class SubmissionListComponent implements OnInit {
 	@Input() onlyShowAccepted: boolean = false
 
 	resultsLength: number = 0
-	isLoadingResults: boolean = true
+	isLoadingResults: boolean = false
 	hasSubmissionsRole: boolean = false
 	selectionQuery: string
 
@@ -59,6 +61,7 @@ export class SubmissionListComponent implements OnInit {
 		public auth: AuthenticationService,
 		public dialog: MatDialog,
 		private snackBar: MatSnackBar,
+		private speedrunEventService: SpeedrunEventService,
 		private submissionService: SubmissionService,
 		private router: Router
 	) { }
@@ -91,38 +94,55 @@ export class SubmissionListComponent implements OnInit {
 
 		if (this.dataSource.data !== undefined) {
 			this.selectionQuery = this.onlyShowAccepted ? 'accept+bonus' : ''
-			merge(this.sort.sortChange, this.paginator.page)
-					.pipe(
-						startWith({}),
-						switchMap(() => {
-							this.isLoadingResults = true
-							return this.submissionService.getSubmissions(
-								this.selectionQuery,
-								this.sort.active,
-								this.sort.direction,
-								this.paginator.pageSize || this.initialPageSize,
-								this.paginator.pageIndex)
-						}),
-						map((data: GameSubmissionResponse) => {
-							this.isLoadingResults = false
-							this.resultsLength = data.total
 
-							return data.docs
-						}),
-						catchError(() => {
-							this.isLoadingResults = false
-							// TODO: Display an error message on the table
-							return observableOf([])
-						})
-					).subscribe((data: GameSubmission[]) => {
-						this.dataSource.data = data
+			if (!this.speedrunEventId) {
+				this.speedrunEventService.getCurrentSpeedrunEvent()
+					.subscribe((srEvent: SpeedrunEvent) => {
+						this.speedrunEventId = srEvent._id
+
+						this.setupTable()
 					})
+			} else {
+				this.setupTable()
+			}
 		} else {
 			this.isLoadingResults = false
 		}
 	}
 
+	setupTable() {
+		merge(this.sort.sortChange, this.paginator.page)
+			.pipe(
+				startWith({}),
+				switchMap(() => {
+					this.isLoadingResults = true
+					console.log('DEBUG: SPEEDRUN EVENT', this.speedrunEventId)
+					return this.submissionService.getSubmissions(
+						this.selectionQuery,
+						this.sort.active,
+						this.sort.direction,
+						this.paginator.pageSize || this.initialPageSize,
+						this.paginator.pageIndex,
+						this.speedrunEventId)
+				}),
+				map((data: GameSubmissionResponse) => {
+					this.isLoadingResults = false
+					this.resultsLength = data.total
+
+					return data.docs
+				}),
+				catchError(() => {
+					this.isLoadingResults = false
+					// TODO: Display an error message on the table
+					return observableOf([])
+				}))
+			.subscribe((data: GameSubmission[]) => {
+				this.dataSource.data = data
+			})
+	}
+
 	applyFilter(filterValue: string) {
+		console.log(this.dataSource)
 		filterValue = filterValue.trim()
 		filterValue = filterValue.toLowerCase()
 		if (filterValue.includes('selection:')) {

--- a/src/app/submission.service.ts
+++ b/src/app/submission.service.ts
@@ -35,6 +35,7 @@ export interface GameSubmission {
 	cons: string
 	public: boolean
 	categories: GameCategory[]
+	speedrunEvent?: string
 }
 
 export interface GameSubmissionResponse {
@@ -65,11 +66,16 @@ export class SubmissionService {
 		return this.http.post(this.apiUrl, submission, options)
 	}
 
-	getSubmissionsForUser(userId: string): Observable<GameSubmissionResponse> {
+	getSubmissionsForUser(userId: string, speedrunEventId: string = ''): Observable<GameSubmissionResponse> {
 		const options = {
 			headers: this.auth.generateAuthHeader(),
 			params: new HttpParams()
 				.set('user', userId)
+		}
+
+		if (speedrunEventId) {
+			// HttpParams.set() is immutable; it returns a new object
+			options.params = options.params.set('speedrunEvent', speedrunEventId)
 		}
 
 		return this.http.get<any>(this.apiUrl, options)

--- a/src/app/submission.service.ts
+++ b/src/app/submission.service.ts
@@ -66,7 +66,7 @@ export class SubmissionService {
 		return this.http.post(this.apiUrl, submission, options)
 	}
 
-	getSubmissionsForUser(userId: string, speedrunEventId: string = ''): Observable<GameSubmissionResponse> {
+	getSubmissionsForUser(userId: string, speedrunEventId?: string): Observable<GameSubmissionResponse> {
 		const options = {
 			headers: this.auth.generateAuthHeader(),
 			params: new HttpParams()
@@ -87,7 +87,8 @@ export class SubmissionService {
 		sort: string = 'name',
 		order: string = 'asc',
 		limit: number = 10,
-		page: number = 0): Observable<GameSubmissionResponse> {
+		page: number = 0,
+		speedrunEventId?: string): Observable<GameSubmissionResponse> {
 		const options = {
 			headers: this.auth.generateAuthHeader(),
 			params: new HttpParams()
@@ -96,6 +97,11 @@ export class SubmissionService {
 				.set('order', order)
 				.set('limit', `${limit}`)
 				.set('page', `${page + 1}`)
+		}
+
+		if (speedrunEventId) {
+			// HttpParams.set() is immutable; it returns a new object
+			options.params = options.params.set('speedrunEvent', speedrunEventId)
 		}
 
 		return this.http.get<any>(this.apiUrl, options)


### PR DESCRIPTION
Basically this is how it should have originally been written. Game submissions are tied to a `SpeedrunEvent` and all pages with SubmissionList check for only those from the active event.