### PR TITLE
change deny log message for getUsers

### DIFF
--- a/controllers/users.controller.js
+++ b/controllers/users.controller.js
@@ -23,10 +23,10 @@ function generateToken (user) {
 
 exports.getUsers = async function (req, res, next) {
 	if (!req.user || !req.user._id || !req.user.roles || !req.user.roles.includes('admin')) {
-		console.warn('Unauthorized speedrun event creation attempted', req.user, req.body)
+		console.warn('Unauthorized user info request attempted', req.user, req.body)
 		return res.status(401).json( {
 			status: 401,
-			message: 'Unauthorized. You do not have permission to create a speedrun event.'
+			message: 'Unauthorized. You do not have permission to get user info.'
 		} )
 	}
 


### PR DESCRIPTION
## Changes

- Update logging message for getUsers

---

Not sure if you particularly care about the log messages. If we wanted to be really picky: if a user isn't in the proper role it'd be more appropriate to throw a 403 forbidden, but I'm guessing there likely isn't gonna be enough traffic here to warrant the difference.